### PR TITLE
Add error handling callback.

### DIFF
--- a/lib/dev.js
+++ b/lib/dev.js
@@ -20,7 +20,11 @@ exports.watch = function (metalsmith, paths) {
 			// Rebuild everything
 			// Inefficient, but neccessary if the change was inside a template
 			// TODO: Inspect filePath and rebuild only required files?
-			metalsmith.build();
+			metalsmith.build(function(err) {
+				if (err) {
+					throw err;
+				}
+			});
 		});
 	});
 };


### PR DESCRIPTION
Since Metalsmith 1.0.0, using `build()` without any parameters will not generate any output. This patch is meant as a temporary workaround until something can land in the core library.

Related: https://github.com/segmentio/metalsmith/issues/92
